### PR TITLE
Comply with eager loading

### DIFF
--- a/lib/vcr/unused_cassettes.rb
+++ b/lib/vcr/unused_cassettes.rb
@@ -5,9 +5,10 @@ require "zeitwerk"
 module VCR
   module UnusedCassettes
     @loader = Zeitwerk::Loader.for_gem_extension(VCR)
+    @loader.do_not_eager_load("#{__dir__}/unused_cassettes/railtie.rb")
     @loader.setup
 
-    require_relative "unused_cassettes/railtie" if defined?(Rails)
+    require_relative "unused_cassettes/railtie" if defined?(::Rails)
 
     class Error < StandardError; end
 

--- a/lib/vcr/unused_cassettes.rb
+++ b/lib/vcr/unused_cassettes.rb
@@ -2,13 +2,17 @@
 
 require "zeitwerk"
 
-loader = Zeitwerk::Loader.for_gem_extension(VCR)
-loader.setup
-
 module VCR
   module UnusedCassettes
+    @loader = Zeitwerk::Loader.for_gem_extension(VCR)
+    @loader.setup
+
     require_relative "unused_cassettes/railtie" if defined?(Rails)
 
     class Error < StandardError; end
+
+    def self.eager_load!
+      @loader.eager_load
+    end
   end
 end

--- a/lib/vcr/unused_cassettes/railtie.rb
+++ b/lib/vcr/unused_cassettes/railtie.rb
@@ -1,14 +1,19 @@
 require "vcr/unused_cassettes"
-require "rails"
 
 module VCR
   module UnusedCassettes
-    class Railtie < Rails::Railtie
-      railtie_name :vcr_unused_cassettes
+    if defined?(::Rails)
+      class Railtie < Rails::Railtie
+        railtie_name :vcr_unused_cassettes
 
-      rake_tasks do
-        path = File.expand_path(__dir__)
-        Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
+        rake_tasks do
+          path = File.expand_path(__dir__)
+          Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
+        end
+      end
+    else
+      # satisfy zeitwerk loading even when rails is not present
+      class Railtie
       end
     end
   end

--- a/lib/vcr/unused_cassettes/railtie.rb
+++ b/lib/vcr/unused_cassettes/railtie.rb
@@ -2,18 +2,12 @@ require "vcr/unused_cassettes"
 
 module VCR
   module UnusedCassettes
-    if defined?(::Rails)
-      class Railtie < Rails::Railtie
-        railtie_name :vcr_unused_cassettes
+    class Railtie < Rails::Railtie
+      railtie_name :vcr_unused_cassettes
 
-        rake_tasks do
-          path = File.expand_path(__dir__)
-          Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
-        end
-      end
-    else
-      # satisfy zeitwerk loading even when rails is not present
-      class Railtie
+      rake_tasks do
+        path = File.expand_path(__dir__)
+        Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require "vcr/unused_cassettes"
 
+VCR::UnusedCassettes.eager_load!
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/vcr/unused_cassettes_spec.rb
+++ b/spec/vcr/unused_cassettes_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe VCR::UnusedCassettes do
   it "has a version number" do
     expect(VCR::UnusedCassettes::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
Using this an application that uses eager loading
would raise an error like

```
lib/vcr/unused_cassettes/configuration.rb to define constant
VCR::UnusedCassettes::Configuration, but didn't (Zeitwerk::NameError)
```

This is now fixed. To enforce to be compliant we use eager loading for the tests.